### PR TITLE
Support for documenting extensions for messages

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -81,7 +81,9 @@ static inline bool longNameLessThan(const QVariant &v1, const QVariant &v2)
 {
     if (v1.toHash()["message_long_name"].toString() < v2.toHash()["message_long_name"].toString())
         return true;
-    return v1.toHash()["enum_long_name"].toString() < v2.toHash()["enum_long_name"].toString();
+    if (v1.toHash()["enum_long_name"].toString() < v2.toHash()["enum_long_name"].toString())
+        return true;
+    return v1.toHash()["extension_long_name"].toString() < v2.toHash()["extension_long_name"].toString();
 }
 
 /**
@@ -223,6 +225,70 @@ static void addField(const gp::FieldDescriptor *fieldDescriptor, QVariantList *f
 }
 
 /**
+ * Add extension to variant list.
+ *
+ * Adds the extension described by @p fieldDescriptor to the variant list @p extensions.
+ */
+static void addExtension(const gp::FieldDescriptor *fieldDescriptor, QVariantList *extensions)
+{
+    QString description = descriptionOf(fieldDescriptor);
+
+    if (description.startsWith("@exclude")) {
+        return;
+    }
+
+    QVariantHash extension;
+
+    // Add basic info.
+    extension["extension_name"] = QString::fromStdString(fieldDescriptor->name());
+    extension["extension_full_name"] = QString::fromStdString(fieldDescriptor->full_name());
+    extension["extension_long_name"] = longName(fieldDescriptor);
+    extension["extension_description"] = description;
+    extension["extension_label"] = labelName(fieldDescriptor->label());
+    extension["extension_number"] = QString::number(fieldDescriptor->number());
+
+    if (fieldDescriptor->is_extension()) {
+        const gp::Descriptor *descriptor = fieldDescriptor->extension_scope();
+        if (descriptor != NULL) {
+            extension["extension_scope_type"] = QString::fromStdString(descriptor->name());
+            extension["extension_scope_long_type"] = longName(descriptor);
+            extension["extension_scope_full_type"] = QString::fromStdString(descriptor->full_name());
+        }
+
+        descriptor = fieldDescriptor->containing_type();
+        if (descriptor != NULL) {
+            extension["extension_containing_type"] = QString::fromStdString(descriptor->name());
+            extension["extension_containing_long_type"] = longName(descriptor);
+            extension["extension_containing_full_type"] = QString::fromStdString(descriptor->full_name());
+        }
+    }
+
+    // Add type information.
+    gp::FieldDescriptor::Type type = fieldDescriptor->type();
+    if (type == gp::FieldDescriptor::TYPE_MESSAGE || type == gp::FieldDescriptor::TYPE_GROUP) {
+        // Field is of message / group type.
+        const gp::Descriptor *descriptor = fieldDescriptor->message_type();
+        extension["extension_type"] = QString::fromStdString(descriptor->name());
+        extension["extension_long_type"] = longName(descriptor);
+        extension["extension_full_type"] = QString::fromStdString(descriptor->full_name());
+    } else if (type == gp::FieldDescriptor::TYPE_ENUM) {
+        // Field is of enum type.
+        const gp::EnumDescriptor *descriptor = fieldDescriptor->enum_type();
+        extension["extension_type"] = QString::fromStdString(descriptor->name());
+        extension["extension_long_type"] = longName(descriptor);
+        extension["extension_full_type"] = QString::fromStdString(descriptor->full_name());
+    } else {
+        // Field is of scalar type.
+        QString typeName(scalarTypeName(type));
+        extension["extension_type"] = typeName;
+        extension["extension_long_type"] = typeName;
+        extension["extension_full_type"] = typeName;
+    }
+
+    extensions->append(extension);
+}
+
+/**
  * Adds the enum described by @p enumDescriptor to the variant list @p enums.
  */
 static void addEnum(const gp::EnumDescriptor *enumDescriptor, QVariantList *enums)
@@ -294,6 +360,14 @@ static void addMessages(const gp::Descriptor *descriptor,
     }
     message["message_fields"] = fields;
 
+    // Add inlined extensions
+    QVariantList extensions;
+    for (int i = 0; i < descriptor->extension_count(); ++i) {
+        addExtension(descriptor->extension(i), &extensions);
+    }
+    message["message_extensions"] = extensions;
+
+
     messages->append(message);
 
     // Add nested messages and enums.
@@ -320,6 +394,7 @@ static void addFile(const gp::FileDescriptor *fileDescriptor, QVariantList *file
 
     QVariantList messages;
     QVariantList enums;
+    QVariantList extensions;
 
     // Add messages.
     for (int i = 0; i < fileDescriptor->message_type_count(); ++i) {
@@ -334,6 +409,13 @@ static void addFile(const gp::FileDescriptor *fileDescriptor, QVariantList *file
     }
     std::sort(enums.begin(), enums.end(), &longNameLessThan);
     file["file_enums"] = enums;
+
+    // Add file-level extensions
+    for (int i = 0; i < fileDescriptor->extension_count(); ++i) {
+        addExtension(fileDescriptor->extension(i), &extensions);
+    }
+    std::sort(extensions.begin(), extensions.end(), &longNameLessThan);
+    file["file_extensions"] = extensions;
 
     files->append(file);
 }

--- a/templates/docbook.mustache
+++ b/templates/docbook.mustache
@@ -14,6 +14,36 @@
         <tgroup cols="4">
           <colspec colwidth="*"/>
           <colspec colwidth="*"/>
+          <colspec colwidth="*"/>
+          <colspec colwidth="0.5*"/>
+          <colspec colwidth="3*"/>
+          <thead>
+            <row>
+              <entry>Extension</entry>
+              <entry>Type</entry>
+              <entry>Base</entry>
+              <entry>Number</entry>
+              <entry>Description</entry>
+            </row>
+          </thead>
+          <tbody>
+            {{#message_extensions}}
+            <row>
+              <entry>{{extension_name}}</entry>
+              <entry><link linkend="{{extension_full_type}}">{{extension_long_type}}</link></entry>
+              <entry><link linkend="{{extension_containing_full_type}}">{{extension_containing_long_type}}</link></entry>
+              <entry>{{extension_number}}</entry>
+              <entry>{{#para}}{{extension_description}}{{/para}}</entry>
+            </row>
+            {{/message_extensions}}
+          </tbody>
+        </tgroup>
+      </informaltable>
+
+      <informaltable frame="all">
+        <tgroup cols="4">
+          <colspec colwidth="*"/>
+          <colspec colwidth="*"/>
           <colspec colwidth="0.5*"/>
           <colspec colwidth="3*"/>
           <thead>
@@ -67,6 +97,14 @@
       </informaltable>
     </section>
     {{/file_enums}}
+
+    {{#file_extensions}}
+    <section {{#extension_full_name}}id="{{extension_full_name}}"{{/extension_full_name}}>
+      <title>{{extension_long_name}}</title>
+      {{#para}}{{extension_description}}{{/para}}
+      {{extension_name}}({{extension_number}}) extends {{extension_containing_long_type}}
+    </section>
+    {{/file_extensions}}
   </section>
   {{/files}}
 

--- a/templates/html.mustache
+++ b/templates/html.mustache
@@ -80,6 +80,23 @@
         width: auto;
       }
 
+      /* Table of fields */
+      .extension-table td:nth-child(1) { /* Extension */
+        width: 10em;
+      }
+      .extension-table td:nth-child(2) { /* Type */
+        width: 10em;
+      }
+      .extension-table td:nth-child(3) { /* Base */
+        width: 10em;
+      }
+      .extension-table td:nth-child(4) { /* Number */
+        width: 5em;
+      }
+      .extension-table td:nth-child(5) { /* Description */
+        width: auto;
+      }
+
       /* Table of enum values. */
       .enum-table td:nth-child(1) { /* Name */
         width: 10em;
@@ -123,7 +140,7 @@
         display: table-cell;
       }
 
-      /* The 'M' and 'E' badges in the ToC */
+      /* The 'M','E' and 'X' badges in the ToC */
       .badge {
         width: 1.6em;
         height: 1.6em;
@@ -175,6 +192,14 @@
               </a>
             </li>
             {{/file_enums}}
+            {{#file_extensions}}
+            <li>
+              <a href="#{{extension_full_name}}">
+                <span class="badge">X</span>
+                {{extension_long_name}}
+              </a>
+            </li>
+            {{/file_extensions}}
           </ul>
         </li>
         {{/files}}
@@ -189,6 +214,23 @@
     {{#file_messages}}
     <h3 id="{{message_full_name}}">{{message_long_name}}</h3>
     {{#p}}{{message_description}}{{/p}}
+    <table class="extension-table">
+      <thead>
+        <tr><td>Extension</td><td>Type</td><td>Base</td><td>Number</td><td>Description</td></tr>
+      </thead>
+      <tbody>
+        {{#message_extensions}}
+        <tr>
+          <td>{{extension_name}}</td>
+          <td><a href="#{{extension_full_type}}">{{extension_long_type}}</a></td>
+          <td><a href="#{{extension_containing_full_type}}">{{extension_containing_long_type}}</a></td>
+          <td>{{extension_number}}</td>
+          <td>{{#p}}{{extension_description}}{{/p}}</td>
+        </tr>
+        {{/message_extensions}}
+      </tbody>
+    </table>
+    <br>
     <table class="field-table">
       <thead>
         <tr><td>Field</td><td>Type</td><td>Label</td><td>Description</td></tr>
@@ -223,6 +265,11 @@
       </tbody>
     </table>
     {{/file_enums}}
+    {{#file_extensions}}
+    <h3 id="{{extension_full_name}}">{{extension_long_name}}</h3>
+    {{#p}}{{extension_description}}{{/p}}
+    {{extension_name}}({{extension_number}}) extends {{extension_containing_long_type}}
+    {{/file_extensions}}
     {{/files}}
 
     <h2 id="scalar-value-types">Scalar Value Types</h2>

--- a/templates/markdown.mustache
+++ b/templates/markdown.mustache
@@ -10,6 +10,9 @@
  {{#file_enums}}
  * [{{enum_long_name}}](#{{enum_full_name}})
  {{/file_enums}}
+ {{#file_extensions}}
+ * [{{extension_long_name}}](#{{extension_full_name}})
+ {{/file_extensions}}
 {{/files}}
 * [Scalar Value Types](#scalar-value-types)
 
@@ -23,6 +26,13 @@
 <a name="{{message_full_name}}"/>
 ### {{message_long_name}}
 {{message_description}}
+
+| Extension | Type | Base | Number | Description |
+| --------- | ---- | ---- | ------ | ----------- |
+{{#message_extensions}}
+| {{extension_name}} | {{extension_long_type}} | {{extension_containing_long_type}} | {{extension_number}} | {{#nobr}}{{extension_description}}{{/nobr}} |
+{{/message_extensions}}
+
 
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
@@ -44,6 +54,15 @@
 {{/enum_values}}
 
 {{/file_enums}}
+
+{{#file_extensions}}
+<a name="{{extension_full_name}}"/>
+### {{extension_long_name}}
+{{extension_description}}
+
+{{extension_name}} extends {{extension_containing_long_type}} at number {{extension_number}}
+{{/file_extensions}}
+
 {{/files}}
 
 <a name="scalar-value-types"/>


### PR DESCRIPTION
With the following .proto:

~~~proto
message Base {
  extensions 100 to max;
}

message Derived {
  extend Base {
    optional Derived derived_extension = 100;
  }
  optional int32 field = 1;
}
~~~

this change allows to document the extension in the `Derived` message
documentation with the following (example) mustache template:

~~~
{{#message_extensions}}
 {{extension_scope_type}} extends {{extension_containing_type}}
 with name: {{extension_name}}
 with extension number: {{extension_number}}
{{/message_extensions}}
~~~

Note that I didn't modify the `example`, as I'm not sure how to add an extension in this data-model.
