### PR TITLE
Markdown doc content shouldn't escape html code

### DIFF
--- a/templates/markdown.mustache
+++ b/templates/markdown.mustache
@@ -25,24 +25,24 @@
 
 ## {{file_name}}
 
-{{#file_description}}{{file_description}}{{/file_description}}
+{{#file_description}}{{& file_description}}{{/file_description}}
 
 {{#file_messages}}
 <a name="{{message_full_name}}"/>
 ### {{message_long_name}}
-{{message_description}}
+{{& message_description}}
 
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
 {{#message_fields}}
-| {{field_name}} | [{{field_long_type}}](#{{field_full_type}}) | {{field_label}} | {{#nobr}}{{field_description}}{{#field_default_value}} Default: {{field_default_value}}{{/field_default_value}}{{/nobr}} |
+| {{field_name}} | [{{field_long_type}}](#{{field_full_type}}) | {{field_label}} | {{#nobr}}{{& field_description}}{{#field_default_value}} Default: {{field_default_value}}{{/field_default_value}}{{/nobr}} |
 {{/message_fields}}
 
 {{#message_has_extensions}}
 | Extension | Type | Base | Number | Description |
 | --------- | ---- | ---- | ------ | ----------- |
 {{#message_extensions}}
-| {{extension_name}} | {{extension_long_type}} | {{extension_containing_long_type}} | {{extension_number}} | {{#nobr}}{{extension_description}}{{#extension_default_value}} Default: {{extension_default_value}}{{/extension_default_value}}{{/nobr}} |
+| {{extension_name}} | {{extension_long_type}} | {{extension_containing_long_type}} | {{extension_number}} | {{#nobr}}{{& extension_description}}{{#extension_default_value}} Default: {{extension_default_value}}{{/extension_default_value}}{{/nobr}} |
 {{/message_extensions}}
 {{/message_has_extensions}}
 
@@ -51,12 +51,12 @@
 {{#file_enums}}
 <a name="{{enum_full_name}}"/>
 ### {{enum_long_name}}
-{{enum_description}}
+{{& enum_description}}
 
 | Name | Number | Description |
 | ---- | ------ | ----------- |
 {{#enum_values}}
-| {{value_name}} | {{value_number}} | {{#nobr}}{{value_description}}{{/nobr}} |
+| {{value_name}} | {{value_number}} | {{#nobr}}{{& value_description}}{{/nobr}} |
 {{/enum_values}}
 
 {{/file_enums}}
@@ -74,12 +74,12 @@
 {{#file_services}}
 <a name="{{service_full_name}}"/>
 ### {{service_name}}
-{{service_description}}
+{{& service_description}}
 
 | Method Name | Request Type | Response Type | Description |
 | ----------- | ------------ | ------------- | ------------|
 {{#service_methods}}
-| {{method_name}} | [{{method_request_long_type}}](#{{method_request_full_type}}) | [{{method_response_long_type}}](#{{method_response_full_type}}) | {{#nobr}}{{method_description}}{{/nobr}} |
+| {{method_name}} | [{{method_request_long_type}}](#{{method_request_full_type}}) | [{{method_response_long_type}}](#{{method_response_full_type}}) | {{#nobr}}{{& method_description}}{{/nobr}} |
 {{/service_methods}}
 
 {{/file_services}}


### PR DESCRIPTION
If it's escaped, It's not possible to write code blocks like this in doc:

```go
nc.Publish("events", &Event{})
```

