### PR TITLE
Don't render empty table when message has no fields

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 protoc-gen-doc
+.qmake.stash
 /Makefile
 *.o
 *.pro.user*

--- a/examples/doc/example.docbook
+++ b/examples/doc/example.docbook
@@ -258,6 +258,16 @@ fictional.</para><para>Author: Elvis Stansvik</para>
 
   </section>
   <section>
+    <title>SpecialCases.proto</title>
+    <para>Special cases for testing</para><para>This is of course entirely fictional/useless model.</para>
+    <section id="com.example.Empty">
+      <title>Empty</title>
+      <para>Represents a message with no fields</para>
+    </section>
+
+
+  </section>
+  <section>
     <title>Vehicle.proto</title>
     <para>Messages describing manufacturers / vehicles.</para>
     <section id="com.example.Manufacturer">

--- a/examples/doc/example.html
+++ b/examples/doc/example.html
@@ -213,6 +213,17 @@
           </ul>
         </li>
         <li>
+          <a href="#SpecialCases.proto">SpecialCases.proto</a>
+          <ul>
+            <li>
+              <a href="#com.example.Empty">
+                <span class="badge">M</span>
+                Empty
+              </a>
+            </li>
+          </ul>
+        </li>
+        <li>
           <a href="#Vehicle.proto">Vehicle.proto</a>
           <ul>
             <li>
@@ -437,6 +448,12 @@ fictional.</p><p>Author: Elvis Stansvik</p>
         </tr>
       </tbody>
     </table>
+    <div class="file-heading">
+      <h2 id="SpecialCases.proto">SpecialCases.proto</h2><a href="#title">Top</a>
+    </div>
+    <p>Special cases for testing</p><p>This is of course entirely fictional/useless model.</p>
+    <h3 id="com.example.Empty">Empty</h3>
+    <p>Represents a message with no fields</p>
     <div class="file-heading">
       <h2 id="Vehicle.proto">Vehicle.proto</h2><a href="#title">Top</a>
     </div>

--- a/examples/doc/example.md
+++ b/examples/doc/example.md
@@ -9,6 +9,8 @@
 * [Customer.proto](#Customer.proto)
  * [Address](#com.example.Address)
  * [Customer](#com.example.Customer)
+* [SpecialCases.proto](#SpecialCases.proto)
+ * [Empty](#com.example.Empty)
 * [Vehicle.proto](#Vehicle.proto)
  * [Manufacturer](#com.example.Manufacturer)
  * [Model](#com.example.Model)
@@ -52,7 +54,7 @@ Represents the status of a vehicle booking.
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
 | id | [int32](#int32) | required | Unique booking status ID. |
-| description | [string](#string) | required | Booking status description. E.g. &quot;Active&quot;. |
+| description | [string](#string) | required | Booking status description. E.g. "Active". |
 
 
 
@@ -109,6 +111,25 @@ Represents a customer.
 
 
 
+<a name="SpecialCases.proto"/>
+<p align="right"><a href="#top">Top</a></p>
+
+## SpecialCases.proto
+
+Special cases for testing
+
+This is of course entirely fictional/useless model.
+
+<a name="com.example.Empty"/>
+### Empty
+Represents a message with no fields
+
+
+
+
+
+
+
 <a name="Vehicle.proto"/>
 <p align="right"><a href="#top">Top</a></p>
 
@@ -123,7 +144,7 @@ Represents a manufacturer of cars.
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
 | id | [int32](#int32) | required | The unique manufacturer ID. |
-| code | [string](#string) | required | A manufacturer code, e.g. &quot;DKL4P&quot;. |
+| code | [string](#string) | required | A manufacturer code, e.g. "DKL4P". |
 | details | [string](#string) | optional | Manufacturer details (minimum orders et.c.). |
 | category | [Manufacturer.Category](#com.example.Manufacturer.Category) | optional | Manufacturer category. Default: CATEGORY_EXTERNAL |
 
@@ -135,8 +156,8 @@ Represents a vehicle model.
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
 | id | [string](#string) | required | The unique model ID. |
-| model_code | [string](#string) | required | The car model code, e.g. &quot;PZ003&quot;. |
-| model_name | [string](#string) | required | The car model name, e.g. &quot;Z3&quot;. |
+| model_code | [string](#string) | required | The car model code, e.g. "PZ003". |
+| model_name | [string](#string) | required | The car model name, e.g. "Z3". |
 | daily_hire_rate_dollars | [sint32](#sint32) | required | Dollars per day. |
 | daily_hire_rate_cents | [sint32](#sint32) | required | Cents per day. |
 
@@ -161,12 +182,12 @@ Represents a vehicle that can be hired.
 
 <a name="com.example.Vehicle.Category"/>
 ### Vehicle.Category
-Represents a vehicle category. E.g. &quot;Sedan&quot; or &quot;Truck&quot;.
+Represents a vehicle category. E.g. "Sedan" or "Truck".
 
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
-| code | [string](#string) | required | Category code. E.g. &quot;S&quot;. |
-| description | [string](#string) | required | Category name. E.g. &quot;Sedan&quot;. |
+| code | [string](#string) | required | Category code. E.g. "S". |
+| description | [string](#string) | required | Category name. E.g. "Sedan". |
 
 
 

--- a/examples/proto/SpecialCases.proto
+++ b/examples/proto/SpecialCases.proto
@@ -1,0 +1,11 @@
+/**
+ * Special cases for testing
+ *
+ * This is of course entirely fictional/useless model.
+ */
+package com.example;
+
+/**
+ * Represents a message with no fields
+ */
+message Empty {}

--- a/examples/templates/asciidoc.mustache
+++ b/examples/templates/asciidoc.mustache
@@ -10,12 +10,14 @@
 === {{message_long_name}}
 {{message_description}}
 
+{{#message_has_fields}}
 |===========================================
 |*Field* |*Type* |*Label* |*Description*
 {{#message_fields}}
 |{{field_name}} | <<{{field_long_type}},{{field_long_type}}>> |{{field_label}} |{{#nobr}}{{field_description}}{{/nobr}}
 {{/message_fields}}
 |===========================================
+{{/message_has_fields}}
 {{/file_messages}}
 
 {{#file_enums}}

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -513,6 +513,7 @@ static void addMessages(const gp::Descriptor *descriptor,
     for (int i = 0; i < descriptor->field_count(); ++i) {
         addField(descriptor->field(i), &fields);
     }
+    message["message_has_fields"] = !fields.isEmpty();
     message["message_fields"] = fields;
 
     // Add nested extensions.

--- a/templates/docbook.mustache
+++ b/templates/docbook.mustache
@@ -9,6 +9,7 @@
     <section {{#message_full_name}}id="{{message_full_name}}"{{/message_full_name}}>
       <title>{{message_long_name}}</title>
       {{#para}}{{message_description}}{{/para}}
+      {{#message_has_fields}}
       <table frame="all">
         <title><classname>{{message_long_name}}</classname> Fields</title>
         <tgroup cols="4">
@@ -36,6 +37,7 @@
           </tbody>
         </tgroup>
       </table>
+      {{/message_has_fields}}
       {{#message_has_extensions}}
       <table frame="all">
         <title><classname>{{message_long_name}}</classname> Nested Extensions</title>

--- a/templates/html.mustache
+++ b/templates/html.mustache
@@ -223,6 +223,7 @@
     {{#file_messages}}
     <h3 id="{{message_full_name}}">{{message_long_name}}</h3>
     {{#p}}{{message_description}}{{/p}}
+    {{#message_has_fields}}
     <table class="field-table">
       <thead>
         <tr><td>Field</td><td>Type</td><td>Label</td><td>Description</td></tr>
@@ -238,6 +239,7 @@
         {{/message_fields}}
       </tbody>
     </table>
+    {{/message_has_fields}}
     {{#message_has_extensions}}
     <br>
     <table class="extension-table">

--- a/templates/markdown.mustache
+++ b/templates/markdown.mustache
@@ -32,11 +32,13 @@
 ### {{message_long_name}}
 {{& message_description}}
 
+{{#message_has_fields}}
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
 {{#message_fields}}
 | {{field_name}} | [{{field_long_type}}](#{{field_full_type}}) | {{field_label}} | {{#nobr}}{{& field_description}}{{#field_default_value}} Default: {{field_default_value}}{{/field_default_value}}{{/nobr}} |
 {{/message_fields}}
+{{/message_has_fields}}
 
 {{#message_has_extensions}}
 | Extension | Type | Base | Number | Description |


### PR DESCRIPTION
@estan 

When generating docs for messages without fields, the generator renders an empty table. This looks kind of broken, so I've added `message_has_fields` so it can be used in a template to decide whether or not to render the table.

I've updated the templates to check for fields before rendering tables and regenerated the examples.

If this gets merged, I'll update the [wiki page](https://github.com/estan/protoc-gen-doc/wiki/Custom-Templates#template-input-data-format)